### PR TITLE
Add seasonal home court advantage map

### DIFF
--- a/data_loader.py
+++ b/data_loader.py
@@ -190,6 +190,15 @@ def load_training_data(
     ).astype(float)
 
     all_data = add_days_since_most_recent_game(all_data)
+
+    # Add per-season HCA values
+    hca_map_path = os.path.join(env.DATA_DIR, "hca_by_year.json")
+    hca_map = utils.load_hca_map(hca_map_path)
+    if not hca_map or any(int(y) not in hca_map for y in all_data["year"].unique()):
+        hca_map = utils.calculate_hca_by_season(all_data)
+        utils.save_hca_map(hca_map, hca_map_path)
+    all_data["hca"] = all_data["year"].map(hca_map).astype(float)
+
     all_data.to_csv(os.path.join(env.DATA_DIR, "train_data.csv"), index=False)
     return all_data
 

--- a/tests/test_duplicate_games.py
+++ b/tests/test_duplicate_games.py
@@ -29,6 +29,7 @@ def test_duplicate_games_basic():
                 "team_win_total_future": 50,
                 "opponent_win_total_future": 30,
                 "team_win": 1,
+                "hca": 2.5,
             }
         ]
     )
@@ -41,5 +42,5 @@ def test_duplicate_games_basic():
     dup = result.iloc[1]
     assert dup["team"] == "B"
     assert dup["opponent"] == "A"
-    assert dup["margin"] == -10 + 2 * utils.HCA
+    assert dup["margin"] == -10 + 2 * 2.5
     # assert dup["rating_diff"] == -10


### PR DESCRIPTION
## Summary
- compute seasonal home court advantage values
- store HCA map and attach seasonal HCA to training data
- use row-wise HCA when duplicating games
- adjust duplicate games test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854132f4f28832fb487e00f57354b4f