### PR TITLE
Fix Kalman bias sign convention and CI failures

### DIFF
--- a/scripts/eval_kalman_bias.py
+++ b/scripts/eval_kalman_bias.py
@@ -33,7 +33,9 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 REPORTS_DIR = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "reports", "experiments"
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "reports",
+    "experiments",
 )
 
 
@@ -148,7 +150,9 @@ def print_metrics_by_segment(result):
         ("Last 20%", gn > np.percentile(gn, 80)),
     ]
 
-    print(f"\n  {'Segment':<14} {'N':>6} {'RMSE Base':>11} {'RMSE Kalman':>13} {'Delta':>8}")
+    print(
+        f"\n  {'Segment':<14} {'N':>6} {'RMSE Base':>11} {'RMSE Kalman':>13} {'Delta':>8}"
+    )
     print(f"  {'-' * 54}")
     for name, mask in segments:
         if mask.sum() == 0:
@@ -221,20 +225,22 @@ def plot_innovation_diagnostics(result, output_path):
 
     # Histogram of raw innovations
     axes[0].hist(innovations, bins=50, edgecolor="black", alpha=0.7)
-    axes[0].set_title(f"Innovation residuals\nmean={np.mean(innovations):.3f}, std={np.std(innovations):.3f}")
+    axes[0].set_title(
+        f"Innovation residuals\nmean={np.mean(innovations):.3f}, std={np.std(innovations):.3f}"
+    )
     axes[0].set_xlabel("Innovation (z - z_hat)")
 
     # Histogram of standardized innovations (should be ~N(0,1))
     axes[1].hist(standardized, bins=50, edgecolor="black", alpha=0.7, density=True)
     x = np.linspace(-4, 4, 100)
-    axes[1].plot(x, np.exp(-x**2 / 2) / np.sqrt(2 * np.pi), "r-", linewidth=2)
-    axes[1].set_title(f"Standardized innovations\nmean={np.mean(standardized):.3f}, std={np.std(standardized):.3f}")
+    axes[1].plot(x, np.exp(-(x**2) / 2) / np.sqrt(2 * np.pi), "r-", linewidth=2)
+    axes[1].set_title(
+        f"Standardized innovations\nmean={np.mean(standardized):.3f}, std={np.std(standardized):.3f}"
+    )
     axes[1].set_xlabel("Standardized innovation")
 
     # Innovation over time
-    axes[2].scatter(
-        range(len(innovations)), innovations, s=1, alpha=0.3
-    )
+    axes[2].scatter(range(len(innovations)), innovations, s=1, alpha=0.3)
     axes[2].axhline(0, color="red", linewidth=0.5)
     axes[2].set_title("Innovations over time")
     axes[2].set_xlabel("Game index")
@@ -269,8 +275,14 @@ def grid_search(games_by_year, xgb_preds_by_year, team_to_idx, test_years):
             games = games_by_year[yr]
             preds = xgb_preds_by_year[yr]
             res = run_kalman_pass(
-                games, preds, team_to_idx,
-                rho=rho, q=q, r=r, init_var=iv, reset_on_season=True,
+                games,
+                preds,
+                team_to_idx,
+                rho=rho,
+                q=q,
+                r=r,
+                init_var=iv,
+                reset_on_season=True,
             )
             all_actuals.append(games["margin"].values)
             all_kalman.append(res["pred_final"].values)
@@ -283,10 +295,17 @@ def grid_search(games_by_year, xgb_preds_by_year, team_to_idx, test_years):
         rmse_k = np.sqrt(mean_squared_error(actuals, kalman))
         rmse_b = np.sqrt(mean_squared_error(actuals, baseline))
 
-        results_log.append({
-            "rho": rho, "q": q, "r": r, "init_var": iv,
-            "rmse_kalman": rmse_k, "rmse_base": rmse_b, "delta": rmse_k - rmse_b,
-        })
+        results_log.append(
+            {
+                "rho": rho,
+                "q": q,
+                "r": r,
+                "init_var": iv,
+                "rmse_kalman": rmse_k,
+                "rmse_base": rmse_b,
+                "delta": rmse_k - rmse_b,
+            }
+        )
 
         if rmse_k < best_rmse:
             best_rmse = rmse_k
@@ -302,7 +321,10 @@ def grid_search(games_by_year, xgb_preds_by_year, team_to_idx, test_years):
 def main():
     parser = argparse.ArgumentParser(description="Evaluate Kalman team bias")
     parser.add_argument(
-        "--test-years", type=int, nargs="+", default=[2023, 2024, 2025],
+        "--test-years",
+        type=int,
+        nargs="+",
+        default=[2023, 2024, 2025],
         help="Years to evaluate on (XGB trained on all prior years)",
     )
     parser.add_argument("--skip-grid", action="store_true", help="Skip grid search")
@@ -319,10 +341,14 @@ def main():
     logger.info(f"Loading training data from {data_path}")
     all_games = pd.read_csv(data_path)
     all_games = all_games[all_games["completed"] == True].copy()
-    all_games = all_games.sort_values(["year", "date", "num_games_into_season"]).reset_index(drop=True)
+    all_games = all_games.sort_values(
+        ["year", "date", "num_games_into_season"]
+    ).reset_index(drop=True)
 
     # Build team index from all teams
-    all_teams = sorted(set(all_games["team"].unique()) | set(all_games["opponent"].unique()))
+    all_teams = sorted(
+        set(all_games["team"].unique()) | set(all_games["opponent"].unique())
+    )
     team_to_idx, idx_to_team = build_team_index(all_teams)
     logger.info(f"Teams: {len(team_to_idx)}")
 
@@ -338,7 +364,9 @@ def main():
             continue
         games_by_year[yr] = test_games.reset_index(drop=True)
         xgb_preds_by_year[yr] = preds
-        logger.info(f"  Year {yr}: {len(test_games)} games, XGB RMSE={np.sqrt(mean_squared_error(test_games['margin'].values, preds)):.4f}")
+        logger.info(
+            f"  Year {yr}: {len(test_games)} games, XGB RMSE={np.sqrt(mean_squared_error(test_games['margin'].values, preds)):.4f}"
+        )
 
     test_years = sorted(games_by_year.keys())
     if not test_years:

--- a/src/team_bias_kalman.py
+++ b/src/team_bias_kalman.py
@@ -38,9 +38,14 @@ class KalmanBiasInfo:
 
     @property
     def team_posteriors(self) -> Dict[str, Tuple[float, float]]:
-        """Return {team: (mean, var)} for compatibility with forecast code."""
+        """Return {team: (mean, var)} for compatibility with forecast code.
+
+        The Kalman filter uses z = actual - pred, so positive bias means the
+        model underpredicts. The forecast/sim code expects the old convention
+        (positive = overprediction), so we negate the means here.
+        """
         return {
-            team: (float(self.mean[i]), float(self.cov[i, i]))
+            team: (float(-self.mean[i]), float(self.cov[i, i]))
             for team, i in self.team_to_idx.items()
         }
 
@@ -50,9 +55,13 @@ class KalmanBiasInfo:
         return float(np.sqrt(np.mean(np.diag(self.cov))))
 
     def draw_biases(self) -> Dict[str, float]:
-        """Draw one sample from the multivariate posterior for simulation."""
+        """Draw one sample from the multivariate posterior for simulation.
+
+        Returns biases in the old convention (positive = model overpredicts),
+        matching what sim_season expects: margin -= home_bias, margin += away_bias.
+        """
         sample = np.random.multivariate_normal(self.mean, self.cov)
-        return {team: float(sample[i]) for team, i in self.team_to_idx.items()}
+        return {team: float(-sample[i]) for team, i in self.team_to_idx.items()}
 
 
 class TeamBiasKalmanFilter:

--- a/src/team_bias_kalman.py
+++ b/src/team_bias_kalman.py
@@ -251,6 +251,9 @@ def compute_kalman_bias(
     """
     from . import utils
 
+    if training_data is None:
+        return None
+
     games = training_data[
         (training_data["year"] == year) & (training_data["completed"] == True)
     ].copy()


### PR DESCRIPTION
## Summary
Follow-up fixes to PR #32 that were pushed to the Kalman branch but landed after the merge.

## Fix 1: Sign convention (critical)
The Kalman filter uses \`z = actual - pred\` (positive bias = model underpredicts the team). But \`forecast.py\` and \`sim_season.py\` expect the old convention where positive = overpredicts, and apply corrections as \`margin - home_bias + away_bias\`. Without this fix, every bias adjustment runs with the wrong sign — boosting teams the model already overrates and penalizing the ones it underrates.

The fix negates the means in \`KalmanBiasInfo.team_posteriors\` and \`draw_biases()\` so the existing forecast/sim logic works correctly.

**Verified**: CHO (Kalman bias +2.2 → underpredicted) now has a predictive rating of +5.7 (vs EM +4.3), which is the correct direction. Before the fix, CHO's pred was pulled *below* its EM.

## Fix 2: CI failures
- \`compute_kalman_bias\` now returns \`None\` when \`training_data\` is \`None\` (test stub case in \`test_main_run.py\`)
- \`scripts/eval_kalman_bias.py\` reformatted with black

## Test plan
- [x] 1000-sim full pipeline produces reasonable standings (OKC 49% champ, SAS 17%)
- [x] Kalman biases sign-check: positive-bias teams get boosted, negative get reduced
- [x] \`test_main_run.py\` passes locally
- [x] \`black --check\` passes