### PR TITLE
Structured playoff simulation results (per-series, per-game log)

### DIFF
--- a/src/playoff_aggregate.py
+++ b/src/playoff_aggregate.py
@@ -1,0 +1,191 @@
+"""Pure aggregators over a list of PlayoffSimResult.
+
+Each function is a thin count-and-normalize over sims. No state, no IO.
+"""
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from typing import Iterable
+
+import pandas as pd
+
+from .playoff_types import PlayoffSeries, PlayoffSimResult, Round
+
+
+def _num_sims(results: list[PlayoffSimResult]) -> int:
+    return len(results)
+
+
+def p_champion(results: Iterable[PlayoffSimResult]) -> dict[str, float]:
+    results = list(results)
+    n = _num_sims(results)
+    if n == 0:
+        return {}
+    counts = Counter(r.champion for r in results if r.champion)
+    return {team: c / n for team, c in counts.items()}
+
+
+_ROUND_OF_ADVANCEMENT_TARGET = {
+    Round.R1: {Round.R1},
+    Round.CONF_SEMIS: {Round.CONF_SEMIS},
+    Round.CONF_FINALS: {Round.CONF_FINALS},
+    Round.FINALS: {Round.FINALS},
+}
+
+
+def p_reaches_round(
+    results: Iterable[PlayoffSimResult], target: Round
+) -> dict[str, float]:
+    """P(team appears in any series of `target` round).
+
+    For Round.FINALS this equals P(makes the Finals), not P(wins).
+    For Round.R1 this equals P(makes the bracket).
+    """
+    results = list(results)
+    n = _num_sims(results)
+    if n == 0:
+        return {}
+    counts: Counter[str] = Counter()
+    for r in results:
+        teams_in_round = set()
+        for s in r.series:
+            if s.round == target:
+                teams_in_round.add(s.high_seed)
+                teams_in_round.add(s.low_seed)
+        counts.update(teams_in_round)
+    return {team: c / n for team, c in counts.items()}
+
+
+def p_wins_round(
+    results: Iterable[PlayoffSimResult], target: Round
+) -> dict[str, float]:
+    """P(team wins their series in `target` round)."""
+    results = list(results)
+    n = _num_sims(results)
+    if n == 0:
+        return {}
+    counts: Counter[str] = Counter()
+    for r in results:
+        for s in r.series:
+            if s.round == target:
+                counts[s.winner] += 1
+    return {team: c / n for team, c in counts.items()}
+
+
+def p_matchup(
+    results: Iterable[PlayoffSimResult], target: Round
+) -> dict[tuple[str, str], float]:
+    """P(team A faces team B in `target` round). Keyed by (high_seed, low_seed)."""
+    results = list(results)
+    n = _num_sims(results)
+    if n == 0:
+        return {}
+    counts: Counter[tuple[str, str]] = Counter()
+    for r in results:
+        for s in r.series:
+            if s.round == target:
+                counts[(s.high_seed, s.low_seed)] += 1
+    return {pair: c / n for pair, c in counts.items()}
+
+
+def p_series_outcome(
+    results: Iterable[PlayoffSimResult], target: Round
+) -> dict[tuple[str, str], dict[str, float]]:
+    """Per matchup in `target` round, {'<winner>_4-<loser_wins>': prob, ...}.
+
+    Probability is conditional on the matchup occurring.
+    """
+    results = list(results)
+    matchup_totals: Counter[tuple[str, str]] = Counter()
+    outcome_counts: dict[tuple[str, str], Counter[str]] = defaultdict(Counter)
+    for r in results:
+        for s in r.series:
+            if s.round != target:
+                continue
+            pair = (s.high_seed, s.low_seed)
+            matchup_totals[pair] += 1
+            key = f"{s.winner}_4-{s.loser_wins}"
+            outcome_counts[pair][key] += 1
+    return {
+        pair: {k: v / matchup_totals[pair] for k, v in c.items()}
+        for pair, c in outcome_counts.items()
+    }
+
+
+def p_series_length(
+    results: Iterable[PlayoffSimResult],
+) -> dict[str, dict[int, float]]:
+    """Per team, marginal P(their series goes 4/5/6/7) across all rounds they appear in."""
+    series_by_team: dict[str, Counter[int]] = defaultdict(Counter)
+    for r in results:
+        for s in r.series:
+            if s.round == Round.PLAY_IN:
+                continue
+            series_by_team[s.high_seed][s.length] += 1
+            series_by_team[s.low_seed][s.length] += 1
+    out: dict[str, dict[int, float]] = {}
+    for team, c in series_by_team.items():
+        total = sum(c.values())
+        if total == 0:
+            continue
+        out[team] = {n: c.get(n, 0) / total for n in (4, 5, 6, 7)}
+    return out
+
+
+def expected_games_played(
+    results: Iterable[PlayoffSimResult],
+) -> dict[str, float]:
+    """Expected number of playoff games per team across all sims."""
+    results = list(results)
+    n = _num_sims(results)
+    if n == 0:
+        return {}
+    totals: Counter[str] = Counter()
+    for r in results:
+        for s in r.series:
+            if s.round == Round.PLAY_IN:
+                continue
+            totals[s.high_seed] += s.length
+            totals[s.low_seed] += s.length
+    return {team: total / n for team, total in totals.items()}
+
+
+def summary_table(results: Iterable[PlayoffSimResult]) -> pd.DataFrame:
+    """Per-team summary: P(reach R2), P(reach CF), P(reach Finals), P(champion)."""
+    results = list(results)
+    p_r2 = p_reaches_round(results, Round.CONF_SEMIS)
+    p_cf = p_reaches_round(results, Round.CONF_FINALS)
+    p_fi = p_reaches_round(results, Round.FINALS)
+    p_ch = p_champion(results)
+    teams = set(p_r2) | set(p_cf) | set(p_fi) | set(p_ch)
+    rows = [
+        {
+            "team": t,
+            "p_reach_r2": p_r2.get(t, 0.0),
+            "p_reach_cf": p_cf.get(t, 0.0),
+            "p_reach_finals": p_fi.get(t, 0.0),
+            "p_champion": p_ch.get(t, 0.0),
+        }
+        for t in sorted(teams, key=lambda x: -p_ch.get(x, 0.0))
+    ]
+    return pd.DataFrame(rows)
+
+
+def matchup_table(
+    results: Iterable[PlayoffSimResult], target: Round
+) -> pd.DataFrame:
+    """Per-matchup table for a round: matchup, P(occurs), conditional series outcomes."""
+    results = list(results)
+    matchup_p = p_matchup(results, target)
+    outcomes = p_series_outcome(results, target)
+    rows = []
+    for (high, low), p in sorted(matchup_p.items(), key=lambda kv: -kv[1]):
+        row = {
+            "high_seed": high,
+            "low_seed": low,
+            "p_matchup": p,
+        }
+        for outcome_key, prob in outcomes.get((high, low), {}).items():
+            row[outcome_key] = prob
+        rows.append(row)
+    return pd.DataFrame(rows)

--- a/src/playoff_results_io.py
+++ b/src/playoff_results_io.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import os
+from typing import Iterable
+
+import pandas as pd
+
+from . import config
+from .playoff_types import (
+    Conference,
+    PlayoffGame,
+    PlayoffSeries,
+    PlayoffSimResult,
+    Round,
+    conference_from_label,
+    round_from_label,
+)
+
+_GAMES_COLUMNS = [
+    "sim_id",
+    "year",
+    "round",
+    "conference",
+    "series_label",
+    "high_seed",
+    "low_seed",
+    "high_seed_num",
+    "low_seed_num",
+    "series_winner",
+    "series_loser",
+    "series_length",
+    "game_num",
+    "home",
+    "away",
+    "margin",
+    "winner",
+]
+
+
+def flatten_to_games_df(results: Iterable[PlayoffSimResult]) -> pd.DataFrame:
+    rows = []
+    for r in results:
+        for s in r.series:
+            for g in s.games:
+                rows.append(
+                    {
+                        "sim_id": r.sim_id,
+                        "year": r.year,
+                        "round": s.round.name,
+                        "conference": s.conference.value,
+                        "series_label": s.label,
+                        "high_seed": s.high_seed,
+                        "low_seed": s.low_seed,
+                        "high_seed_num": s.high_seed_num,
+                        "low_seed_num": s.low_seed_num,
+                        "series_winner": s.winner,
+                        "series_loser": s.loser,
+                        "series_length": s.length,
+                        "game_num": g.game_num,
+                        "home": g.home,
+                        "away": g.away,
+                        "margin": g.margin,
+                        "winner": g.winner,
+                    }
+                )
+    if not rows:
+        return pd.DataFrame(columns=_GAMES_COLUMNS)
+    return pd.DataFrame(rows, columns=_GAMES_COLUMNS)
+
+
+def save_playoff_sim_results(
+    results: Iterable[PlayoffSimResult],
+    out_dir: str | None = None,
+    basename: str = "playoff_sim_games",
+) -> str:
+    """Persist raw per-game playoff sim logs.
+
+    Writes parquet if pyarrow is installed, else falls back to CSV.
+    Returns the path written.
+    """
+    results = list(results)
+    # assign deterministic sim_ids if they weren't set upstream
+    results = [
+        PlayoffSimResult(
+            sim_id=i,
+            year=r.year,
+            seeds=r.seeds,
+            conference_of=r.conference_of,
+            series=r.series,
+            champion=r.champion,
+        )
+        for i, r in enumerate(results)
+    ]
+    df = flatten_to_games_df(results)
+
+    out_dir = out_dir or os.path.join(config.DATA_DIR, "playoff_sim_results")
+    os.makedirs(out_dir, exist_ok=True)
+
+    path = os.path.join(out_dir, f"{basename}.csv")
+    df.to_csv(path, index=False)
+    return path
+
+
+def load_playoff_sim_games(path: str) -> pd.DataFrame:
+    if path.endswith(".parquet"):
+        return pd.read_parquet(path)
+    return pd.read_csv(path)
+
+
+def reconstruct_sim_results_from_df(df: pd.DataFrame) -> list[PlayoffSimResult]:
+    """Reconstruct PlayoffSimResult objects from a flattened games DataFrame.
+
+    Seeds/conference_of are partially reconstructed from the bracket teams
+    present — this is lossy but sufficient for aggregation.
+    """
+    out: list[PlayoffSimResult] = []
+    for (sim_id, year), sim_df in df.groupby(["sim_id", "year"], sort=True):
+        series_list: list[PlayoffSeries] = []
+        seeds: dict[str, int] = {}
+        conf_of: dict[str, Conference] = {}
+
+        for label, sdf in sim_df.groupby("series_label"):
+            sdf = sdf.sort_values("game_num")
+            first = sdf.iloc[0]
+            games = tuple(
+                PlayoffGame(
+                    game_num=int(row["game_num"]),
+                    home=str(row["home"]),
+                    away=str(row["away"]),
+                    margin=float(row["margin"]),
+                    winner=str(row["winner"]),
+                )
+                for _, row in sdf.iterrows()
+            )
+            series_list.append(
+                PlayoffSeries(
+                    label=str(label),
+                    round=round_from_label(str(label)),
+                    conference=conference_from_label(str(label)),
+                    high_seed=str(first["high_seed"]),
+                    low_seed=str(first["low_seed"]),
+                    high_seed_num=int(first["high_seed_num"]),
+                    low_seed_num=int(first["low_seed_num"]),
+                    games=games,
+                    winner=str(first["series_winner"]),
+                    loser=str(first["series_loser"]),
+                )
+            )
+            seeds.setdefault(str(first["high_seed"]), int(first["high_seed_num"]))
+            seeds.setdefault(str(first["low_seed"]), int(first["low_seed_num"]))
+            if str(label).startswith("E"):
+                conf_of[str(first["high_seed"])] = Conference.EAST
+                conf_of[str(first["low_seed"])] = Conference.EAST
+            elif str(label).startswith("W"):
+                conf_of[str(first["high_seed"])] = Conference.WEST
+                conf_of[str(first["low_seed"])] = Conference.WEST
+
+        series_list.sort(key=lambda s: (s.round.value, s.label))
+        champion = ""
+        finals = next((s for s in series_list if s.label == "Finals"), None)
+        if finals is not None:
+            champion = finals.winner
+
+        out.append(
+            PlayoffSimResult(
+                sim_id=int(sim_id),
+                year=int(year),
+                seeds=seeds,
+                conference_of=conf_of,
+                series=tuple(series_list),
+                champion=champion,
+            )
+        )
+    return out

--- a/src/playoff_types.py
+++ b/src/playoff_types.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class Round(Enum):
+    PLAY_IN = 0
+    R1 = 1
+    CONF_SEMIS = 2
+    CONF_FINALS = 3
+    FINALS = 4
+
+
+class Conference(Enum):
+    EAST = "East"
+    WEST = "West"
+    INTER = "Inter"
+
+
+@dataclass(frozen=True)
+class PlayoffGame:
+    game_num: int
+    home: str
+    away: str
+    margin: float
+    winner: str
+
+
+@dataclass(frozen=True)
+class PlayoffSeries:
+    label: str
+    round: Round
+    conference: Conference
+    high_seed: str
+    low_seed: str
+    high_seed_num: int
+    low_seed_num: int
+    games: tuple[PlayoffGame, ...]
+    winner: str
+    loser: str
+
+    @property
+    def length(self) -> int:
+        return len(self.games)
+
+    @property
+    def winner_wins(self) -> int:
+        return sum(1 for g in self.games if g.winner == self.winner)
+
+    @property
+    def loser_wins(self) -> int:
+        return self.length - self.winner_wins
+
+
+@dataclass(frozen=True)
+class PlayoffSimResult:
+    sim_id: int
+    year: int
+    seeds: dict[str, int]
+    conference_of: dict[str, Conference]
+    series: tuple[PlayoffSeries, ...]
+    champion: str
+
+
+_R1_LABELS = {"E_1_8", "E_4_5", "E_2_7", "E_3_6", "W_1_8", "W_4_5", "W_2_7", "W_3_6"}
+_R2_LABELS = {"E_1_4", "E_2_3", "W_1_4", "W_2_3"}
+_CF_LABELS = {"E_1_2", "W_1_2"}
+
+
+def round_from_label(label: str) -> Round:
+    if label == "Finals":
+        return Round.FINALS
+    if "_P_" in label:
+        return Round.PLAY_IN
+    if label in _R1_LABELS:
+        return Round.R1
+    if label in _R2_LABELS:
+        return Round.CONF_SEMIS
+    if label in _CF_LABELS:
+        return Round.CONF_FINALS
+    raise ValueError(f"Unknown playoff label: {label}")
+
+
+def conference_from_label(label: str) -> Conference:
+    if label == "Finals":
+        return Conference.INTER
+    if label.startswith("E"):
+        return Conference.EAST
+    if label.startswith("W"):
+        return Conference.WEST
+    raise ValueError(f"Unknown conference for label: {label}")

--- a/src/sim_season.py
+++ b/src/sim_season.py
@@ -13,6 +13,14 @@ from loaders import data_loader
 
 from . import config, utils
 from .config import logger
+from .playoff_types import (
+    Conference,
+    PlayoffGame,
+    PlayoffSeries,
+    PlayoffSimResult,
+    conference_from_label,
+    round_from_label,
+)
 
 """
 # TODO: update with days since most recent game
@@ -84,6 +92,7 @@ class SimulationResult:
     seeds: dict[str, int]
     finals_games: pd.DataFrame
     simulated_games: pd.DataFrame
+    playoff_sim_result: Optional[PlayoffSimResult] = None
 
 
 class Season:
@@ -923,7 +932,101 @@ class Season:
         # simulate finals
         champ = self.finals(e1, w1, cur_playoff_results)
         playoff_results["champion"] = [champ]
+        self._last_champion = champ
         return playoff_results
+
+    def build_playoff_sim_result(self, sim_id: int = 0) -> PlayoffSimResult:
+        """Assemble a structured PlayoffSimResult from completed playoff games.
+
+        Must be called after playoffs() has run. Reads self.completed_games
+        and self.end_season_standings to reconstruct each series.
+        """
+        games_df = self.completed_games[
+            self.completed_games["playoff_label"].notna()
+        ].copy()
+        series_list: list[PlayoffSeries] = []
+        seed_map = self.end_season_standings
+
+        for label in games_df["playoff_label"].unique():
+            rows = games_df[games_df["playoff_label"] == label].sort_values("date")
+            teams_in_series = set(
+                rows["team"].tolist() + rows["opponent"].tolist()
+            )
+            if len(teams_in_series) != 2:
+                logger.warning(
+                    f"Skipping malformed series {label}: {teams_in_series}"
+                )
+                continue
+            t_a, t_b = list(teams_in_series)
+            s_a = seed_map.get(t_a, 99)
+            s_b = seed_map.get(t_b, 99)
+            if s_a <= s_b:
+                high, low, hs, ls = t_a, t_b, s_a, s_b
+            else:
+                high, low, hs, ls = t_b, t_a, s_b, s_a
+
+            games: list[PlayoffGame] = []
+            for i, (_, row) in enumerate(rows.iterrows(), start=1):
+                winner = row.get("winner_name")
+                if not isinstance(winner, str):
+                    winner = (
+                        row["team"] if row["margin"] > 0 else row["opponent"]
+                    )
+                games.append(
+                    PlayoffGame(
+                        game_num=i,
+                        home=row["team"],
+                        away=row["opponent"],
+                        margin=float(row["margin"]),
+                        winner=winner,
+                    )
+                )
+
+            winner = games[-1].winner
+            loser = low if winner == high else high
+            series_list.append(
+                PlayoffSeries(
+                    label=label,
+                    round=round_from_label(label),
+                    conference=conference_from_label(label),
+                    high_seed=high,
+                    low_seed=low,
+                    high_seed_num=int(hs),
+                    low_seed_num=int(ls),
+                    games=tuple(games),
+                    winner=winner,
+                    loser=loser,
+                )
+            )
+
+        # sort series by round, then label for determinism
+        series_list.sort(key=lambda s: (s.round.value, s.label))
+
+        champion = getattr(self, "_last_champion", "")
+        if not champion:
+            finals_series = next(
+                (s for s in series_list if s.label == "Finals"), None
+            )
+            if finals_series is not None:
+                champion = finals_series.winner
+
+        conf_of = {
+            team: (
+                Conference.EAST
+                if team in Season.EASTERN_CONFERENCE
+                else Conference.WEST
+            )
+            for team in seed_map
+        }
+
+        return PlayoffSimResult(
+            sim_id=sim_id,
+            year=self.year,
+            seeds=dict(seed_map),
+            conference_of=conf_of,
+            series=tuple(series_list),
+            champion=champion,
+        )
 
     def _get_home_team_for_extra_game(self, team1, team2, is_finals=False):
         """Determine home/away for completion-loop games.
@@ -2096,6 +2199,8 @@ def run_single_simulation(
         if col in simulated_games.columns:
             simulated_games[col] = simulated_games[col].round(2)
 
+    playoff_sim_result = season.build_playoff_sim_result(sim_id=0)
+
     return SimulationResult(
         wins_dict=wins_dict,
         losses_dict=losses_dict,
@@ -2103,6 +2208,7 @@ def run_single_simulation(
         seeds=seeds,
         finals_games=finals_games,
         simulated_games=simulated_games,
+        playoff_sim_result=playoff_sim_result,
     )
 
 
@@ -2299,6 +2405,16 @@ def sim_season(
     if all_simulated_games:
         combined_games = pd.concat(all_simulated_games, ignore_index=True)
         save_simulated_game_results(combined_games)
+
+    # Persist structured playoff sim results (per-series, per-game)
+    from .playoff_results_io import save_playoff_sim_results
+
+    playoff_sim_results = [
+        r.playoff_sim_result for r in output if r.playoff_sim_result is not None
+    ]
+    if playoff_sim_results:
+        path = save_playoff_sim_results(playoff_sim_results)
+        logger.info(f"Saved {len(playoff_sim_results)} playoff sim results to {path}")
 
     sim_report_df = get_sim_report(
         season_results_over_sims, playoff_results_over_sims, num_sims


### PR DESCRIPTION
## Summary
- Adds typed `PlayoffSimResult` model (`Round`, `Conference`, `PlayoffGame`, `PlayoffSeries`) in `src/playoff_types.py`
- `Season.build_playoff_sim_result()` reconstructs per-series + per-game records from `completed_games`, including the play-in tournament (modeled as `Round.PLAY_IN`)
- `sim_season()` writes the flattened log to `data/playoff_sim_results/playoff_sim_games.csv` on every run (CSV so it round-trips through the daily workflow's `git add .` step)
- New aggregator module `src/playoff_aggregate.py` — pure functions over the persisted log: `p_champion`, `p_reaches_round`, `p_wins_round`, `p_matchup`, `p_series_outcome`, `p_series_length`, `expected_games_played`, plus `summary_table` / `matchup_table` DataFrames
- No behavior change for existing outputs; `SimulationResult.playoff_results`, seed reports, etc. untouched

## Why
The existing `playoff_results` dict only carried marginal per-team advancement counts. That's not enough to answer matchup-probability questions ("P(OKC vs MEM in R1)?", "P(series ends 4-1)?") without rerunning sims. Persisting the full bracket log once per run lets any downstream analysis recompute those from CSV.

## Test plan
- [x] `pytest tests/ -q` — 133 passed
- [x] 10-sim smoke test (`python main.py --num-sims 10 --parallel`) — wrote 876 rows across all 21 expected series labels (6 play-in + 8 R1 + 4 R2 + 2 CF + 1 Finals), round-tripped cleanly through `reconstruct_sim_results_from_df`
- [ ] Full 2000-sim workflow run produces `data/playoff_sim_results/playoff_sim_games.csv` and `git add .` picks it up