### PR TITLE
Emit pre-aggregated playoff_slot_probs.json alongside sim CSV

### DIFF
--- a/src/playoff_results_io.py
+++ b/src/playoff_results_io.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 import os
+from collections import defaultdict
 from typing import Iterable
 
 import pandas as pd
@@ -98,6 +100,102 @@ def save_playoff_sim_results(
 
     path = os.path.join(out_dir, f"{basename}.csv")
     df.to_csv(path, index=False)
+    return path
+
+
+_BRACKET_ROUNDS = {Round.R1, Round.CONF_SEMIS, Round.CONF_FINALS, Round.FINALS}
+
+
+def save_playoff_slot_probs(
+    results: Iterable[PlayoffSimResult],
+    out_dir: str | None = None,
+    basename: str = "playoff_slot_probs",
+) -> str:
+    """Persist a compact JSON of per-slot win probabilities by series length.
+
+    Output schema:
+        {
+          "year": int,
+          "n_sims": int,
+          "slots": [
+            {
+              "round": "R1" | "CONF_SEMIS" | "CONF_FINALS" | "FINALS",
+              "conference": "East" | "West" | "Inter",
+              "slot": "E_1_8" | ... | "Finals",
+              "candidates": [
+                {"team": "DET", "seed": 1, "wins": [w4, w5, w6, w7]},
+                ...
+              ]
+            }
+          ]
+        }
+
+    `wins` are raw counts across sims for series length 4/5/6/7. Divide by
+    `n_sims` on the client for marginal probabilities. Play-in rounds are
+    excluded.
+    """
+    results = list(results)
+    n_sims = len(results)
+    year = results[0].year if results else None
+
+    # slot_key -> {round, conference, slot, teams: {abbr -> {seed, wins[4]}}}
+    slots: dict[tuple, dict] = {}
+
+    for r in results:
+        for s in r.series:
+            if s.round not in _BRACKET_ROUNDS:
+                continue
+            key = (s.round.name, s.conference.value, s.label)
+            entry = slots.setdefault(
+                key,
+                {
+                    "round": s.round.name,
+                    "conference": s.conference.value,
+                    "slot": s.label,
+                    "teams": defaultdict(
+                        lambda: {"seed": None, "wins": [0, 0, 0, 0]}
+                    ),
+                },
+            )
+            # record seed hints for both participants
+            for abbr, seed_num in (
+                (s.high_seed, s.high_seed_num),
+                (s.low_seed, s.low_seed_num),
+            ):
+                t = entry["teams"][abbr]
+                if t["seed"] is None and seed_num:
+                    t["seed"] = seed_num
+            # count the winner at this length bucket
+            length = s.length
+            if 4 <= length <= 7:
+                entry["teams"][s.winner]["wins"][length - 4] += 1
+
+    slot_list = []
+    for entry in slots.values():
+        cands = [
+            {"team": abbr, "seed": t["seed"], "wins": t["wins"]}
+            for abbr, t in entry["teams"].items()
+            if sum(t["wins"]) > 0
+        ]
+        cands.sort(key=lambda c: -sum(c["wins"]))
+        slot_list.append(
+            {
+                "round": entry["round"],
+                "conference": entry["conference"],
+                "slot": entry["slot"],
+                "candidates": cands,
+            }
+        )
+
+    slot_list.sort(key=lambda s: (s["round"], s["conference"], s["slot"]))
+
+    payload = {"year": year, "n_sims": n_sims, "slots": slot_list}
+
+    out_dir = out_dir or os.path.join(config.DATA_DIR, "playoff_sim_results")
+    os.makedirs(out_dir, exist_ok=True)
+    path = os.path.join(out_dir, f"{basename}.json")
+    with open(path, "w") as fh:
+        json.dump(payload, fh, separators=(",", ":"))
     return path
 
 

--- a/src/sim_season.py
+++ b/src/sim_season.py
@@ -2407,7 +2407,7 @@ def sim_season(
         save_simulated_game_results(combined_games)
 
     # Persist structured playoff sim results (per-series, per-game)
-    from .playoff_results_io import save_playoff_sim_results
+    from .playoff_results_io import save_playoff_sim_results, save_playoff_slot_probs
 
     playoff_sim_results = [
         r.playoff_sim_result for r in output if r.playoff_sim_result is not None
@@ -2415,6 +2415,8 @@ def sim_season(
     if playoff_sim_results:
         path = save_playoff_sim_results(playoff_sim_results)
         logger.info(f"Saved {len(playoff_sim_results)} playoff sim results to {path}")
+        probs_path = save_playoff_slot_probs(playoff_sim_results)
+        logger.info(f"Saved playoff slot probabilities to {probs_path}")
 
     sim_report_df = get_sim_report(
         season_results_over_sims, playoff_results_over_sims, num_sims


### PR DESCRIPTION
## Summary

- Adds `save_playoff_slot_probs()` to `src/playoff_results_io.py` which writes a compact per-slot win-probability summary to `data/playoff_sim_results/playoff_slot_probs.json` keyed by bracket position and series length (4/5/6/7 games).
- Wires the call into `simulate_season_many` in `src/sim_season.py` right after the existing `save_playoff_sim_results` call, so both files are produced on every sim run.
- ~4.8 KB output at 2,000 sims vs the ~14 MB per-game CSV — ~3000× smaller, letting downstream consumers (e.g. the bracket page on kyle-cox.com) fetch and render instantly instead of parsing 177k CSV rows client-side.

## Output schema

\`\`\`json
{
  "year": 2026,
  "n_sims": 2000,
  "slots": [
    {
      "round": "R1",
      "conference": "East",
      "slot": "E_1_8",
      "candidates": [
        {"team": "DET", "seed": 1, "wins": [349, 548, 413, 281]},
        {"team": "CHO", "seed": 9, "wins": [51, 56, 79, 83]}
      ]
    }
  ]
}
\`\`\`

`wins[i]` is the raw count of sims where that team won the slot in `i+4` games. Clients divide by `n_sims` for marginal probabilities. Play-in rounds are excluded (the bracket starts at R1).

## Test plan

- [x] Smoke-tested end-to-end against the currently-published `playoff_sim_games.csv` via `reconstruct_sim_results_from_df` → `save_playoff_slot_probs`; output matches the CSV-derived probabilities (e.g. DET wins E_1_8 slot in 79.5% of sims, matching what the bracket visualization showed).
- [ ] Verify the daily workflow writes both files and commits them to `data/playoff_sim_results/`.