### PR TITLE
Fix daily update workflow: filter playoff games from future sim set

### DIFF
--- a/src/sim_season.py
+++ b/src/sim_season.py
@@ -2326,6 +2326,16 @@ def sim_season(
     else:
         completed_year_games = year_games[year_games["completed"] == True]
         future_year_games = year_games[year_games["completed"] == False]
+        # Filter out playoff games from future_year_games so that
+        # simulate_season() only runs regular season games.  The playoffs()
+        # method generates its own playoff bracket and games dynamically;
+        # leaving data-file playoff rows here causes phantom results that
+        # conflict with the freshly-seeded bracket (e.g. real-schedule
+        # first-round matchups don't match the sim's play-in-determined
+        # 7/8 seeds, leaving series like W_2_7 with zero games and
+        # raising "No games found for series" during playoffs()).
+        playoff_start = utils.get_playoff_start_date(year).date()
+        future_year_games = future_year_games[future_year_games["date"] < playoff_start]
 
     start_time = time.time()
     if parallel:


### PR DESCRIPTION
The sim_season() entry point was only filtering out playoff games from
future_year_games when a --start-date was provided. When start_date was
None (the default used in the daily update workflow), scheduled real
playoff games remained in future_year_games and were simulated by
simulate_season() with the real-schedule team matchups.

playoffs() then re-simulated the play-in tournament to pick its own
7/8 seeds, which frequently didn't match the real-schedule 7/8 seeds.
When sim-generated first-round matchups (e.g. W_2_7) didn't correspond
to any real-schedule matchup already simulated, simulate_series() found
no games to label and no games to schedule (because the series appeared
"complete" via stale cur_playoff_results bookkeeping), leaving the
series empty and raising "ValueError: No games found for series W_2_7"
in get_series_winner().

Apply the same playoff-date filter that the start_date branch uses so
the simulator always generates its own bracket cleanly.