### PR TITLE
style: apply black formatting to playoff modules

### DIFF
--- a/src/playoff_aggregate.py
+++ b/src/playoff_aggregate.py
@@ -2,6 +2,7 @@
 
 Each function is a thin count-and-normalize over sims. No state, no IO.
 """
+
 from __future__ import annotations
 
 from collections import Counter, defaultdict
@@ -171,9 +172,7 @@ def summary_table(results: Iterable[PlayoffSimResult]) -> pd.DataFrame:
     return pd.DataFrame(rows)
 
 
-def matchup_table(
-    results: Iterable[PlayoffSimResult], target: Round
-) -> pd.DataFrame:
+def matchup_table(results: Iterable[PlayoffSimResult], target: Round) -> pd.DataFrame:
     """Per-matchup table for a round: matchup, P(occurs), conditional series outcomes."""
     results = list(results)
     matchup_p = p_matchup(results, target)

--- a/src/playoff_results_io.py
+++ b/src/playoff_results_io.py
@@ -152,9 +152,7 @@ def save_playoff_slot_probs(
                     "round": s.round.name,
                     "conference": s.conference.value,
                     "slot": s.label,
-                    "teams": defaultdict(
-                        lambda: {"seed": None, "wins": [0, 0, 0, 0]}
-                    ),
+                    "teams": defaultdict(lambda: {"seed": None, "wins": [0, 0, 0, 0]}),
                 },
             )
             # record seed hints for both participants

--- a/src/sim_season.py
+++ b/src/sim_season.py
@@ -949,13 +949,9 @@ class Season:
 
         for label in games_df["playoff_label"].unique():
             rows = games_df[games_df["playoff_label"] == label].sort_values("date")
-            teams_in_series = set(
-                rows["team"].tolist() + rows["opponent"].tolist()
-            )
+            teams_in_series = set(rows["team"].tolist() + rows["opponent"].tolist())
             if len(teams_in_series) != 2:
-                logger.warning(
-                    f"Skipping malformed series {label}: {teams_in_series}"
-                )
+                logger.warning(f"Skipping malformed series {label}: {teams_in_series}")
                 continue
             t_a, t_b = list(teams_in_series)
             s_a = seed_map.get(t_a, 99)
@@ -969,9 +965,7 @@ class Season:
             for i, (_, row) in enumerate(rows.iterrows(), start=1):
                 winner = row.get("winner_name")
                 if not isinstance(winner, str):
-                    winner = (
-                        row["team"] if row["margin"] > 0 else row["opponent"]
-                    )
+                    winner = row["team"] if row["margin"] > 0 else row["opponent"]
                 games.append(
                     PlayoffGame(
                         game_num=i,
@@ -1004,9 +998,7 @@ class Season:
 
         champion = getattr(self, "_last_champion", "")
         if not champion:
-            finals_series = next(
-                (s for s in series_list if s.label == "Finals"), None
-            )
+            finals_series = next((s for s in series_list if s.label == "Finals"), None)
             if finals_series is not None:
                 champion = finals_series.winner
 


### PR DESCRIPTION
## Summary

- Runs `black` on three files that were drifting from the formatter config enforced by the `lint` job in `.github/workflows/test.yml`
- No behavior changes — whitespace and line-wrap only

## Files

- `src/playoff_aggregate.py`
- `src/playoff_results_io.py`
- `src/sim_season.py`

## Test plan

- [x] `black --check .` passes
- [x] `isort --check-only .` passes
- [x] `flake8 . --select=E9,F63,F7,F82` passes (0 violations)
- [ ] CI `lint` job goes green