### PR TITLE
Fix play-in winner derivation and pandas 3.0 fillna

### DIFF
--- a/src/sim_season.py
+++ b/src/sim_season.py
@@ -1433,9 +1433,7 @@ class Season:
                     playoff_label=label,
                 )
             self.update_data(games_on_date=self.future_games.tail(len(matchups)))
-            self.simulate_day(
-                game_date, game_date + datetime.timedelta(days=3), 1
-            )
+            self.simulate_day(game_date, game_date + datetime.timedelta(days=3), 1)
             results = {}
             for team_a, team_b, label in matchups:
                 sim_game = self.completed_games[

--- a/src/sim_season.py
+++ b/src/sim_season.py
@@ -1408,7 +1408,12 @@ class Season:
             match = matches.sort_values("date").iloc[0]
             idx = match.name
             self.completed_games.loc[idx, "playoff_label"] = label
-            winner = match["winner_name"]
+            # Derive winner from margin (winner_name is wiped by playoffs()).
+            if match["margin"] > 0:
+                winner = match["team"]
+            else:
+                winner = match["opponent"]
+            self.completed_games.loc[idx, "winner_name"] = winner
             loser = team_b if winner == team_a else team_a
             return winner, loser
 

--- a/src/sim_season.py
+++ b/src/sim_season.py
@@ -573,9 +573,9 @@ class Season:
 
         if self.future_games["num_games_into_season"].isnull().any():
             # this only works for playoffs
-            self.future_games["num_games_into_season"].fillna(
-                len(self.completed_games), inplace=True
-            )
+            self.future_games["num_games_into_season"] = self.future_games[
+                "num_games_into_season"
+            ].fillna(len(self.completed_games))
 
         if self.future_games["pace"].isnull().any():
             # Vectorized pace generation - much faster than list comprehension

--- a/tests/test_play_in_detection.py
+++ b/tests/test_play_in_detection.py
@@ -15,7 +15,11 @@ from src.sim_season import Season
 
 
 def _playin_game(team, opponent, date, margin):
-    """Build a completed play-in game row (home perspective, no label yet)."""
+    """Build a completed play-in game row (home perspective, no label yet).
+
+    ``winner_name`` and ``playoff_label`` are ``None`` to mirror what
+    ``playoffs()`` does at line 871-872 before calling ``play_in()``.
+    """
     return {
         "team": team,
         "opponent": opponent,
@@ -27,7 +31,7 @@ def _playin_game(team, opponent, date, margin):
         "year": 2026,
         "pace": 100.0,
         "playoff_label": None,
-        "winner_name": team if margin > 0 else opponent,
+        "winner_name": None,  # wiped by playoffs() before play_in() is called
     }
 
 

--- a/tests/test_play_in_detection.py
+++ b/tests/test_play_in_detection.py
@@ -37,9 +37,7 @@ def _playin_game(team, opponent, date, margin):
 
 def _standings_df(teams):
     """Build a minimal conference standings df with seeds 1..len(teams)."""
-    return pd.DataFrame(
-        {"team": teams, "seed": list(range(1, len(teams) + 1))}
-    )
+    return pd.DataFrame({"team": teams, "seed": list(range(1, len(teams) + 1))})
 
 
 class FakePlayInSeason:
@@ -78,7 +76,9 @@ class FakePlayInSeason:
             base = base.date()
         return base + datetime.timedelta(days=day_increment)
 
-    def append_future_game(self, future_games, date, team, opponent, playoff_label=None):
+    def append_future_game(
+        self, future_games, date, team, opponent, playoff_label=None
+    ):
         new_row = pd.DataFrame(
             {
                 "date": [date],
@@ -90,16 +90,20 @@ class FakePlayInSeason:
                 "winner_name": [np.nan],
             }
         )
-        self.future_games = pd.concat(
-            [self.future_games, new_row], ignore_index=True
-        )
+        self.future_games = pd.concat([self.future_games, new_row], ignore_index=True)
         # Match real Season bookkeeping so .tail() / .loc[] work.
         self.completed_games.index = range(len(self.completed_games))
         self.future_games.index = range(
-            (max(self.completed_games.index) + 1)
-            if len(self.completed_games) > 0
-            else 0,
-            (max(self.completed_games.index) + 1 if len(self.completed_games) > 0 else 0)
+            (
+                (max(self.completed_games.index) + 1)
+                if len(self.completed_games) > 0
+                else 0
+            ),
+            (
+                max(self.completed_games.index) + 1
+                if len(self.completed_games) > 0
+                else 0
+            )
             + len(self.future_games),
         )
 
@@ -107,9 +111,8 @@ class FakePlayInSeason:
         return  # no-op for tests
 
     def simulate_day(self, start_date, end_date, date_increment=1):
-        mask = (
-            (self.future_games["date"] >= start_date)
-            & (self.future_games["date"] < end_date)
+        mask = (self.future_games["date"] >= start_date) & (
+            self.future_games["date"] < end_date
         )
         games = self.future_games[mask].copy()
         if games.empty:
@@ -215,18 +218,14 @@ def test_already_played_full_playin_is_detected():
 
     # Every play-in game in completed_games got a label.
     playin_labels = {"E_P_1", "E_P_2", "E_P_3", "W_P_1", "W_P_2", "W_P_3"}
-    labels_present = set(
-        season.completed_games["playoff_label"].dropna().unique()
-    )
+    labels_present = set(season.completed_games["playoff_label"].dropna().unique())
     assert playin_labels == labels_present
 
 
 def test_no_playin_games_played_simulates_all():
     """When no play-in games are in completed_games, all 6 get simulated."""
     # Need at least one completed game so get_next_date has a reference point.
-    stub_game = _playin_game(
-        "BOS", "NYK", datetime.date(2026, 4, 12), margin=1
-    )
+    stub_game = _playin_game("BOS", "NYK", datetime.date(2026, 4, 12), margin=1)
     stub_game["playoff"] = 0
     completed = pd.DataFrame([stub_game])
 


### PR DESCRIPTION
## Summary

- **Fix wiped `winner_name`**: `playoffs()` clears `winner_name` on all completed games before calling `play_in()`. The new `find_and_label_completed` helper was reading the (now-None) value, causing round-2 matchups to have `None` teams and crashing with `KeyError: None`. Now derives winner from `margin` instead.
- **Fix `fillna(inplace=True)` under pandas 3.0**: Under Copy-on-Write semantics, `df[col].fillna(val, inplace=True)` is silently a no-op, leaving `num_games_into_season` as NaN on dynamically-created play-in/playoff games. Replaced with assignment form `df[col] = df[col].fillna(val)`.
- Updated tests to set `winner_name` to `None` matching the real runtime state after `playoffs()` wipes it.

## Test plan

- [x] All 80 existing tests pass
- [x] All 4 play-in detection tests pass (with `winner_name=None` reflecting production state)
- [x] Full single-simulation run (`python main.py --num-sims 1 --year 2026`) completes successfully end-to-end

https://claude.ai/code/session_01QMRtEHwN51SWGBKPUyP2L7