### PR TITLE
Fix silent data corruption in predictive ratings calculation

### DIFF
--- a/src/forecast.py
+++ b/src/forecast.py
@@ -139,7 +139,8 @@ def get_predictive_ratings_win_margin(
     filename = os.path.join(config.DATA_DIR, "train_data.csv")
     most_recent_games_dict = {}  # team to pandas series of most recent game
     # most recent game is either the most recently played game OR the next game to be played (if no games have been played yet)
-    this_year_games = pd.read_csv(filename)[pd.read_csv(filename)["year"] == year]
+    all_games = pd.read_csv(filename)
+    this_year_games = all_games[all_games["year"] == year]
     this_year_games_completed = this_year_games[this_year_games["completed"] == True]
     this_year_games_completed.sort_values(by="date", ascending=False, inplace=True)
     this_year_games_future = this_year_games[this_year_games["completed"] == False]
@@ -164,7 +165,7 @@ def get_predictive_ratings_win_margin(
             most_recent_games_dict[team] = team_next_game
 
     this_year_games = pd.DataFrame(most_recent_games_dict.values())
-    this_year_games.sort_values(by="date", ascending=False)
+    this_year_games = this_year_games.sort_values(by="date", ascending=True)
     num_games_into_season = len(this_year_games_completed)
     this_year_ratings = {}
     last_year_ratings = {}
@@ -173,7 +174,9 @@ def get_predictive_ratings_win_margin(
         this_year_games_for_team = this_year_games[
             (this_year_games["team"] == team) | (this_year_games["opponent"] == team)
         ]
-        this_year_games_for_team.sort_values(by="date", ascending=False)
+        this_year_games_for_team = this_year_games_for_team.sort_values(
+            by="date", ascending=True
+        )
         most_recent_game = this_year_games_for_team.iloc[-1]
         if most_recent_game["team"] == team:
             this_year_ratings[team] = most_recent_game["team_rating"]

--- a/src/utils.py
+++ b/src/utils.py
@@ -435,7 +435,8 @@ def days_since_most_recent_game(team, date, games, cap=10, hca: float = HCA):
     if len(team_data) == 0:
         return cap
     else:
-        return min(cap, (date - team_data.iloc[0]["date"]).days)
+        team_data = team_data.sort_values(by="date")
+        return min(cap, (date - team_data.iloc[-1]["date"]).days)
 
 
 def build_model_features(df):


### PR DESCRIPTION
## Summary

Four bugs found in the predictive-ratings path. The first two silently corrupt the values written to `predictive_ratings.csv` / `predictive_ratings_playoff.csv`; the third makes a helper return wrong values (currently dormant); the fourth is a wasted file read.

### `src/forecast.py:142` — duplicate CSV read
`pd.read_csv(filename)[pd.read_csv(filename)["year"] == year]` parsed `train_data.csv` twice. Read once, filter once.

### `src/forecast.py:167` — discarded sort
```python
this_year_games.sort_values(by="date", ascending=False)   # result thrown away
```
`this_year_games` was built from a dict, so it stayed in dict-insertion (team) order. The `iloc[-1]` lookups at lines 195–260 (`team_last_10_rating`, `team_last_5_rating`, `team_last_3_rating`, `team_last_1_rating`, `team_win_total_future`, `team_bayesian_gs`) then pulled features from an arbitrary row — a different team's most-recent game involving this team, possibly weeks earlier — and fed those into the win-margin model.

### `src/forecast.py:176` — discarded sort + wrong direction
```python
this_year_games_for_team.sort_values(by="date", ascending=False)   # discarded
most_recent_game = this_year_games_for_team.iloc[-1]
```
Sort was discarded, and even if it had taken effect, `ascending=False` + `iloc[-1]` returns the *oldest* row, not the most recent. The variable `most_recent_game` then drove `this_year_ratings[team]` and `last_year_ratings[team]`, which feed every downstream win-margin prediction. Fixed by ascending sort so `iloc[-1]` is the most recent.

### `src/utils.py:438` — days since the wrong game
```python
return min(cap, (date - team_data.iloc[0]["date"]).days)
```
After `flip_perspective` concatenates the flipped half there is no sort, so `iloc[0]` is whichever row landed first — typically one of the season's earliest games — making the function effectively pinned to `cap`. Currently dormant (the active path is `loaders/data_loader.add_days_since_most_recent_game`, which is correct), but the helper itself was wrong.

## Test plan
- [x] `pytest tests/test_utils_data.py tests/test_utils_ratings.py` — 48 passed
- [ ] Verify next daily update produces sensible `predictive_ratings.csv` values


---
_Generated by [Claude Code](https://claude.ai/code/session_01TRA7gacjWovNfKRUKUBUHE)_