### PR TITLE
style: fix lint failure in playoff_results_io.py

### DIFF
--- a/src/playoff_results_io.py
+++ b/src/playoff_results_io.py
@@ -7,8 +7,7 @@ from typing import Iterable
 
 import pandas as pd
 
-from . import config
-from . import utils
+from . import config, utils
 from .playoff_types import (
     Conference,
     PlayoffGame,
@@ -153,8 +152,7 @@ def build_actual_series_results(
             pair_slot_counts[pair][(s.round.name, s.conference.value, s.label)] += 1
 
     pair_to_slot: dict[frozenset, tuple[str, str, str]] = {
-        pair: counter.most_common(1)[0][0]
-        for pair, counter in pair_slot_counts.items()
+        pair: counter.most_common(1)[0][0] for pair, counter in pair_slot_counts.items()
     }
 
     # Group real games by the pair of teams involved.


### PR DESCRIPTION
## Summary
- Applies `black` and `isort` to `src/playoff_results_io.py` to fix pre-existing formatting drift that was failing the `lint` CI job.

The file was last touched in `f652c57` ("Attach real-world series status to playoff bracket slots") with formatting that the current black/isort versions reject. Surfaced on PR #43 but unrelated to those changes — would fail on main as well.

Two purely cosmetic changes:
- Combine `from . import config` + `from . import utils` into one line.
- Fold a dict comprehension onto one line.

## Test plan
- [x] `black --check .` clean
- [x] `isort --check-only .` clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01TRA7gacjWovNfKRUKUBUHE)_