### PR TITLE
Drop DataFrame intermediates in favor of dicts/vectorized ops

### DIFF
--- a/src/forecast.py
+++ b/src/forecast.py
@@ -121,6 +121,36 @@ def predict_margin_and_win_prob_future_games(
     return games
 
 
+def _team_features_from_game(team, row):
+    """Extract features for ``team`` from the most-recent-game row.
+
+    Each row stores features as ``team_*`` / ``opponent_*`` based on which side
+    the game was originally recorded from. Pick the right side for ``team`` so
+    callers never have to repeat the side check.
+    """
+    if row["team"] == team:
+        return {
+            "rating": row["team_rating"],
+            "last_year_rating": row["last_year_team_rating"],
+            "last_10_rating": row["team_last_10_rating"],
+            "last_5_rating": row["team_last_5_rating"],
+            "last_3_rating": row["team_last_3_rating"],
+            "last_1_rating": row["team_last_1_rating"],
+            "win_total_future": row["team_win_total_future"],
+            "bayesian_gs": row["team_bayesian_gs"],
+        }
+    return {
+        "rating": row["opponent_rating"],
+        "last_year_rating": row["last_year_opp_rating"],
+        "last_10_rating": row["opponent_last_10_rating"],
+        "last_5_rating": row["opponent_last_5_rating"],
+        "last_3_rating": row["opponent_last_3_rating"],
+        "last_1_rating": row["opponent_last_1_rating"],
+        "win_total_future": row["opponent_win_total_future"],
+        "bayesian_gs": row["opp_bayesian_gs"],
+    }
+
+
 def get_predictive_ratings_win_margin(
     teams, model, year, playoff_mode=False, team_bias_info=None
 ):
@@ -137,155 +167,64 @@ def get_predictive_ratings_win_margin(
     'team_last_10_rating', 'opponent_last_10_rating', 'team_last_5_rating', 'opponent_last_5_rating', 'team_last_3_rating', 'opponent_last_3_rating', 'team_last_1_rating', 'opponent_last_1_rating'])
     """
     filename = os.path.join(config.DATA_DIR, "train_data.csv")
-    most_recent_games_dict = {}  # team to pandas series of most recent game
-    # most recent game is either the most recently played game OR the next game to be played (if no games have been played yet)
     all_games = pd.read_csv(filename)
     this_year_games = all_games[all_games["year"] == year]
-    this_year_games_completed = this_year_games[this_year_games["completed"] == True]
-    this_year_games_completed.sort_values(by="date", ascending=False, inplace=True)
-    this_year_games_future = this_year_games[this_year_games["completed"] == False]
-    this_year_games_future.sort_values(by="date", ascending=True, inplace=True)
+    completed = this_year_games[this_year_games["completed"] == True].sort_values(
+        by="date", ascending=False
+    )
+    future = this_year_games[this_year_games["completed"] == False].sort_values(
+        by="date", ascending=True
+    )
+
+    # Most recent (or next, if none played yet) game per team, normalized to
+    # that team's perspective.
+    team_snapshots = {}
     for team in teams:
-        team_most_recent_game_df = this_year_games_completed[
-            (this_year_games_completed["team"] == team)
-            | (this_year_games_completed["opponent"] == team)
+        team_completed = completed[
+            (completed["team"] == team) | (completed["opponent"] == team)
         ]
-        if len(team_most_recent_game_df) > 0:
-            team_most_recent_game = team_most_recent_game_df.iloc[0]
-            most_recent_games_dict[team] = team_most_recent_game
-        else:
-            continue  # no games played yet, so we'll get the next game to be played
+        if len(team_completed) > 0:
+            team_snapshots[team] = _team_features_from_game(
+                team, team_completed.iloc[0]
+            )
+            continue
+        team_future = future[(future["team"] == team) | (future["opponent"] == team)]
+        if len(team_future) > 0:
+            team_snapshots[team] = _team_features_from_game(team, team_future.iloc[0])
 
-    for team in teams:
-        if team not in most_recent_games_dict:
-            team_next_game = this_year_games_future[
-                (this_year_games_future["team"] == team)
-                | (this_year_games_future["opponent"] == team)
-            ].iloc[0]
-            most_recent_games_dict[team] = team_next_game
+    teams = list(team_snapshots.keys())
+    num_games_into_season = len(completed)
+    DAYS_SINCE_DEFAULT = 3
 
-    this_year_games = pd.DataFrame(most_recent_games_dict.values())
-    this_year_games = this_year_games.sort_values(by="date", ascending=True)
-    num_games_into_season = len(this_year_games_completed)
-    this_year_ratings = {}
-    last_year_ratings = {}
-    for team in teams:
-        # get games where team was either the opponent or the team
-        this_year_games_for_team = this_year_games[
-            (this_year_games["team"] == team) | (this_year_games["opponent"] == team)
-        ]
-        this_year_games_for_team = this_year_games_for_team.sort_values(
-            by="date", ascending=True
-        )
-        most_recent_game = this_year_games_for_team.iloc[-1]
-        if most_recent_game["team"] == team:
-            this_year_ratings[team] = most_recent_game["team_rating"]
-            last_year_ratings[team] = most_recent_game["last_year_team_rating"]
-        else:
-            this_year_ratings[team] = most_recent_game["opponent_rating"]
-            last_year_ratings[team] = most_recent_game["last_year_opp_rating"]
-
-    teams = list(this_year_ratings.keys())
     team_predictive_em = {}
     for team in teams:
+        t = team_snapshots[team]
         team_home_margins = []
         team_away_margins = []
-        team_rating = this_year_ratings[team]
-        team_df = this_year_games[
-            (this_year_games["team"] == team) | (this_year_games["opponent"] == team)
-        ]
-        team_last_10_rating = (
-            team_df["team_last_10_rating"].iloc[-1]
-            if team_df["team"].iloc[-1] == team
-            else team_df["opponent_last_10_rating"].iloc[-1]
-        )
-        team_last_5_rating = (
-            team_df["team_last_5_rating"].iloc[-1]
-            if team_df["team"].iloc[-1] == team
-            else team_df["opponent_last_5_rating"].iloc[-1]
-        )
-        team_last_3_rating = (
-            team_df["team_last_3_rating"].iloc[-1]
-            if team_df["team"].iloc[-1] == team
-            else team_df["opponent_last_3_rating"].iloc[-1]
-        )
-        team_last_1_rating_rating = (
-            team_df["team_last_1_rating"].iloc[-1]
-            if team_df["team"].iloc[-1] == team
-            else team_df["opponent_last_1_rating"].iloc[-1]
-        )
-        team_win_total_future = (
-            team_df["team_win_total_future"].iloc[-1]
-            if team_df["team"].iloc[-1] == team
-            else team_df["opponent_win_total_future"].iloc[-1]
-        )
-        team_days_since_most_recent_game = 3
-        team_bayesian_gs = (
-            team_df["team_bayesian_gs"].iloc[-1]
-            if team_df["team"].iloc[-1] == team
-            else team_df["opp_bayesian_gs"].iloc[-1]
-        )
-
         for opp in teams:
-            opp_rating = this_year_ratings[opp]
-            opp_df = this_year_games[
-                (this_year_games["team"] == opp) | (this_year_games["opponent"] == opp)
-            ]
-            opp_last_10_rating = (
-                opp_df["team_last_10_rating"].iloc[-1]
-                if opp_df["team"].iloc[-1] == opp
-                else opp_df["opponent_last_10_rating"].iloc[-1]
-            )
-            opp_last_5_rating = (
-                opp_df["team_last_5_rating"].iloc[-1]
-                if opp_df["team"].iloc[-1] == opp
-                else opp_df["opponent_last_5_rating"].iloc[-1]
-            )
-            opp_last_3_rating = (
-                opp_df["team_last_3_rating"].iloc[-1]
-                if opp_df["team"].iloc[-1] == opp
-                else opp_df["opponent_last_3_rating"].iloc[-1]
-            )
-            opp_last_1_rating_rating = (
-                opp_df["team_last_1_rating"].iloc[-1]
-                if opp_df["team"].iloc[-1] == opp
-                else opp_df["opponent_last_1_rating"].iloc[-1]
-            )
-            opp_win_total_future = (
-                opp_df["team_win_total_future"].iloc[-1]
-                if opp_df["team"].iloc[-1] == opp
-                else opp_df["opponent_win_total_future"].iloc[-1]
-            )
-            opp_days_since_most_recent_game = 3
-            opp_bayesian_gs = (
-                opp_df["team_bayesian_gs"].iloc[-1]
-                if opp_df["team"].iloc[-1] == opp
-                else opp_df["opp_bayesian_gs"].iloc[-1]
-            )
-
-            # play a home game
+            o = team_snapshots[opp]
             X_home_base = {
-                "team_rating": team_rating,
-                "opponent_rating": opp_rating,
-                "team_win_total_future": team_win_total_future,
-                "opponent_win_total_future": opp_win_total_future,
-                "last_year_team_rating": last_year_ratings[team],
-                "last_year_opp_rating": last_year_ratings[opp],
+                "team_rating": t["rating"],
+                "opponent_rating": o["rating"],
+                "team_win_total_future": t["win_total_future"],
+                "opponent_win_total_future": o["win_total_future"],
+                "last_year_team_rating": t["last_year_rating"],
+                "last_year_opp_rating": o["last_year_rating"],
                 "num_games_into_season": num_games_into_season,
-                "team_last_10_rating": team_last_10_rating,
-                "opponent_last_10_rating": opp_last_10_rating,
-                "team_last_5_rating": team_last_5_rating,
-                "opponent_last_5_rating": opp_last_5_rating,
-                "team_last_3_rating": team_last_3_rating,
-                "opponent_last_3_rating": opp_last_3_rating,
-                "team_last_1_rating": team_last_1_rating_rating,
-                "opponent_last_1_rating": opp_last_1_rating_rating,
-                "team_days_since_most_recent_game": team_days_since_most_recent_game,
-                "opponent_days_since_most_recent_game": opp_days_since_most_recent_game,
+                "team_last_10_rating": t["last_10_rating"],
+                "opponent_last_10_rating": o["last_10_rating"],
+                "team_last_5_rating": t["last_5_rating"],
+                "opponent_last_5_rating": o["last_5_rating"],
+                "team_last_3_rating": t["last_3_rating"],
+                "opponent_last_3_rating": o["last_3_rating"],
+                "team_last_1_rating": t["last_1_rating"],
+                "opponent_last_1_rating": o["last_1_rating"],
+                "team_days_since_most_recent_game": DAYS_SINCE_DEFAULT,
+                "opponent_days_since_most_recent_game": DAYS_SINCE_DEFAULT,
                 "hca": current_hca,
                 "playoff": 1 if playoff_mode else 0,
-                "team_bayesian_gs": team_bayesian_gs,
-                "opp_bayesian_gs": opp_bayesian_gs,
+                "team_bayesian_gs": t["bayesian_gs"],
+                "opp_bayesian_gs": o["bayesian_gs"],
             }
             X_home = utils.build_model_features(pd.DataFrame([X_home_base]))
             home_pred = model.predict(X_home[config.x_features])[0]
@@ -294,35 +233,35 @@ def get_predictive_ratings_win_margin(
                 home_pred += team_bias_info.team_posteriors.get(opp, (0, 0))[0]
             team_home_margins.append(home_pred)
 
-            # play an away game
+            # Same matchup, swapping which team is home.
             X_away_base = {
-                "team_rating": opp_rating,
-                "opponent_rating": team_rating,
-                "team_win_total_future": opp_win_total_future,
-                "opponent_win_total_future": team_win_total_future,
-                "last_year_team_rating": last_year_ratings[opp],
-                "last_year_opp_rating": last_year_ratings[team],
+                "team_rating": o["rating"],
+                "opponent_rating": t["rating"],
+                "team_win_total_future": o["win_total_future"],
+                "opponent_win_total_future": t["win_total_future"],
+                "last_year_team_rating": o["last_year_rating"],
+                "last_year_opp_rating": t["last_year_rating"],
                 "num_games_into_season": num_games_into_season,
-                "team_last_10_rating": opp_last_10_rating,
-                "opponent_last_10_rating": team_last_10_rating,
-                "team_last_5_rating": opp_last_5_rating,
-                "opponent_last_5_rating": team_last_5_rating,
-                "team_last_3_rating": opp_last_3_rating,
-                "opponent_last_3_rating": team_last_3_rating,
-                "team_last_1_rating": opp_last_1_rating_rating,
-                "opponent_last_1_rating": team_last_1_rating_rating,
-                "team_days_since_most_recent_game": opp_days_since_most_recent_game,
-                "opponent_days_since_most_recent_game": team_days_since_most_recent_game,
+                "team_last_10_rating": o["last_10_rating"],
+                "opponent_last_10_rating": t["last_10_rating"],
+                "team_last_5_rating": o["last_5_rating"],
+                "opponent_last_5_rating": t["last_5_rating"],
+                "team_last_3_rating": o["last_3_rating"],
+                "opponent_last_3_rating": t["last_3_rating"],
+                "team_last_1_rating": o["last_1_rating"],
+                "opponent_last_1_rating": t["last_1_rating"],
+                "team_days_since_most_recent_game": DAYS_SINCE_DEFAULT,
+                "opponent_days_since_most_recent_game": DAYS_SINCE_DEFAULT,
                 "hca": current_hca,
                 "playoff": 1 if playoff_mode else 0,
-                "team_bayesian_gs": opp_bayesian_gs,
-                "opp_bayesian_gs": team_bayesian_gs,
+                "team_bayesian_gs": o["bayesian_gs"],
+                "opp_bayesian_gs": t["bayesian_gs"],
             }
             X_away = utils.build_model_features(pd.DataFrame([X_away_base]))
             away_pred = -model.predict(X_away[config.x_features])[0]
             if team_bias_info is not None:
-                # away_pred is from team's perspective (negated home pred)
-                # opp is home here, team is away; we correct from team's perspective
+                # away_pred is from team's perspective (negated home pred);
+                # opp is home, team is away, correct from team's perspective.
                 away_pred += team_bias_info.team_posteriors.get(opp, (0, 0))[0]
                 away_pred -= team_bias_info.team_posteriors.get(team, (0, 0))[0]
             team_away_margins.append(away_pred)

--- a/src/sim_season.py
+++ b/src/sim_season.py
@@ -859,11 +859,10 @@ class Season:
         win_loss_report = self.get_win_loss_report()
         self.regular_season_win_loss_report = win_loss_report
         ec_standings, wc_standings = self.get_playoff_standings(win_loss_report)
-        self.end_season_standings = {}
-        for idx, row in ec_standings.iterrows():
-            self.end_season_standings[row["team"]] = row["seed"]
-        for idx, row in wc_standings.iterrows():
-            self.end_season_standings[row["team"]] = row["seed"]
+        self.end_season_standings = {
+            **dict(zip(ec_standings["team"], ec_standings["seed"])),
+            **dict(zip(wc_standings["team"], wc_standings["seed"])),
+        }
 
         self.future_games["playoff_label"] = None
         self.future_games["winner_name"] = None
@@ -1096,22 +1095,23 @@ class Season:
             game_date = self.get_next_date(day_increment=3)
             num_played_sofar = wins + losses
 
+            series_rows = []
             for i in range(rem_games):
                 g_idx = num_played_sofar + i
                 team1_home = team1_home_map[g_idx]
                 new_dates.add(game_date)
-
-                if team1_home:
-                    self.append_future_game(
-                        self.future_games, game_date, team1, team2, label
-                    )
-                else:
-                    self.append_future_game(
-                        self.future_games, game_date, team2, team1, label
-                    )
-
-                num_games_added += 1
+                home, away = (team1, team2) if team1_home else (team2, team1)
+                series_rows.append(
+                    {
+                        "date": game_date,
+                        "team": home,
+                        "opponent": away,
+                        "playoff_label": label,
+                    }
+                )
                 game_date += datetime.timedelta(days=3)
+            self.append_future_games(series_rows)
+            num_games_added += len(series_rows)
 
         # simulate anything we just added
         if num_games_added:
@@ -1424,14 +1424,17 @@ class Season:
             if not matchups:
                 return {}
             game_date = self.get_next_date(day_increment=3)
-            for team_a, team_b, label in matchups:
-                self.append_future_game(
-                    self.future_games,
-                    date=game_date,
-                    team=team_a,
-                    opponent=team_b,
-                    playoff_label=label,
-                )
+            self.append_future_games(
+                [
+                    {
+                        "date": game_date,
+                        "team": team_a,
+                        "opponent": team_b,
+                        "playoff_label": label,
+                    }
+                    for team_a, team_b, label in matchups
+                ]
+            )
             self.update_data(games_on_date=self.future_games.tail(len(matchups)))
             self.simulate_day(game_date, game_date + datetime.timedelta(days=3), 1)
             results = {}
@@ -1521,27 +1524,48 @@ class Season:
 
         return ec_seeds, wc_seeds
 
-    def append_future_game(
-        self, future_games, date, team, opponent, playoff_label=None
-    ):
-        new_row = pd.DataFrame(
-            {
-                "date": date,
-                "team": team,
-                "opponent": opponent,
-                "year": self.year,
-                "playoff_label": playoff_label,
-            },
-            index=[0],
+    def append_future_games(self, rows):
+        """Append multiple future-game rows in a single concat.
+
+        ``rows`` is a list of dicts with keys ``date``, ``team``, ``opponent``,
+        and optional ``playoff_label``. Doing one concat (instead of one per
+        row) avoids quadratic blow-up when a playoff series schedules 7 games.
+        """
+        if not rows:
+            return
+        new_df = pd.DataFrame(
+            [
+                {
+                    "date": r["date"],
+                    "team": r["team"],
+                    "opponent": r["opponent"],
+                    "year": self.year,
+                    "playoff_label": r.get("playoff_label"),
+                }
+                for r in rows
+            ]
         )
-        new_row = utils.add_playoff_indicator(new_row)
-        self.future_games = pd.concat([self.future_games, new_row], ignore_index=True)
-        # new index
-        # TODO: this is a hack, fix it
+        new_df = utils.add_playoff_indicator(new_df)
+        self.future_games = pd.concat([self.future_games, new_df], ignore_index=True)
+        # Re-index so completed and future indices stay disjoint and contiguous.
         self.completed_games.index = range(len(self.completed_games))
         self.future_games.index = range(
             max(self.completed_games.index) + 1,
             max(self.completed_games.index) + len(self.future_games) + 1,
+        )
+
+    def append_future_game(
+        self, future_games, date, team, opponent, playoff_label=None
+    ):
+        self.append_future_games(
+            [
+                {
+                    "date": date,
+                    "team": team,
+                    "opponent": opponent,
+                    "playoff_label": playoff_label,
+                }
+            ]
         )
 
     def get_next_date(self, day_increment=1):

--- a/src/stats.py
+++ b/src/stats.py
@@ -61,54 +61,31 @@ def get_regular_season_wins_losses(game_df):
     return wins, losses
 
 
-def get_offensive_efficiency(data):
-    # TODO: Fix missing pace data issue - pace should be fetched from nba_api for all completed games
-    # WORKAROUND: Use default pace when missing
-    DEFAULT_PACE = 100.0  # League average pace
+# TODO: Fix missing pace data issue - pace should be fetched from nba_api
+# for all completed games. Until then, fall back to league-average pace.
+DEFAULT_PACE = 100.0
 
-    off_eff = {}
-    for idx, row in data.iterrows():
-        home_points = row["team_score"]
-        away_points = row["opponent_score"]
-        pace = row["pace"] if pd.notna(row["pace"]) else DEFAULT_PACE
-        home_off_eff = home_points / pace
-        away_off_eff = away_points / pace
-        home = row["team"]
-        away = row["opponent"]
-        if home not in off_eff:
-            off_eff[home] = []
-        if away not in off_eff:
-            off_eff[away] = []
-        off_eff[row["team"]].append(home_off_eff)
-        off_eff[row["opponent"]].append(away_off_eff)
-    for team, off_effs in off_eff.items():
-        off_eff[team] = np.mean(off_effs)
-    return off_eff
+
+def _team_efficiency(data, points_col_for_team, points_col_for_opponent):
+    """Average per-team efficiency = points / pace, summed across both
+    sides of every game and grouped by team."""
+    pace = data["pace"].fillna(DEFAULT_PACE)
+    by_team_side = pd.DataFrame(
+        {"team": data["team"], "eff": data[points_col_for_team] / pace}
+    )
+    by_opp_side = pd.DataFrame(
+        {"team": data["opponent"], "eff": data[points_col_for_opponent] / pace}
+    )
+    combined = pd.concat([by_team_side, by_opp_side], ignore_index=True)
+    return combined.groupby("team")["eff"].mean().to_dict()
+
+
+def get_offensive_efficiency(data):
+    return _team_efficiency(data, "team_score", "opponent_score")
 
 
 def get_defensive_efficiency(data):
-    # TODO: Fix missing pace data issue - pace should be fetched from nba_api for all completed games
-    # WORKAROUND: Use default pace when missing
-    DEFAULT_PACE = 100.0  # League average pace
-
-    def_eff = {}
-    for idx, row in data.iterrows():
-        home_points = row["team_score"]
-        away_points = row["opponent_score"]
-        pace = row["pace"] if pd.notna(row["pace"]) else DEFAULT_PACE
-        home_def_eff = away_points / pace
-        away_def_eff = home_points / pace
-        home = row["team"]
-        away = row["opponent"]
-        if home not in def_eff:
-            def_eff[home] = []
-        if away not in def_eff:
-            def_eff[away] = []
-        def_eff[row["team"]].append(home_def_eff)
-        def_eff[row["opponent"]].append(away_def_eff)
-    for team, def_effs in def_eff.items():
-        def_eff[team] = np.mean(def_effs)
-    return def_eff
+    return _team_efficiency(data, "opponent_score", "team_score")
 
 
 def get_adjusted_efficiencies(data, off_eff, def_eff):
@@ -233,20 +210,14 @@ def get_pace(data):
 
 def get_remaining_sos(ratings_df, future_games):
     # returns a dictionary of remaining strength of schedule for each team
-    valid_teams = set(ratings_df["team"].unique())
-    remaining_sos = {team: [] for team in valid_teams}
-    for idx, row in future_games.iterrows():
-        team = row["team"]
-        opponent = row["opponent"]
+    rating_by_team = dict(zip(ratings_df["team"], ratings_df["predictive_rating"]))
+    remaining_sos = {team: [] for team in rating_by_team}
+    for team, opponent in zip(future_games["team"], future_games["opponent"]):
         # Skip games involving non-NBA teams (e.g., exhibition games)
-        if team not in valid_teams or opponent not in valid_teams:
+        if team not in rating_by_team or opponent not in rating_by_team:
             continue
-        remaining_sos[team].append(
-            ratings_df[ratings_df["team"] == opponent]["predictive_rating"].values[0]
-        )
-        remaining_sos[opponent].append(
-            ratings_df[ratings_df["team"] == team]["predictive_rating"].values[0]
-        )
+        remaining_sos[team].append(rating_by_team[opponent])
+        remaining_sos[opponent].append(rating_by_team[team])
     for team in remaining_sos:
         remaining_sos[team] = np.mean(remaining_sos[team])
     return remaining_sos

--- a/tests/test_play_in_detection.py
+++ b/tests/test_play_in_detection.py
@@ -76,35 +76,45 @@ class FakePlayInSeason:
             base = base.date()
         return base + datetime.timedelta(days=day_increment)
 
+    def append_future_games(self, rows):
+        if not rows:
+            return
+        new_df = pd.DataFrame(
+            [
+                {
+                    "date": r["date"],
+                    "team": r["team"],
+                    "opponent": r["opponent"],
+                    "year": self.year,
+                    "playoff_label": r.get("playoff_label"),
+                    "playoff": 1,
+                    "winner_name": np.nan,
+                }
+                for r in rows
+            ]
+        )
+        self.future_games = pd.concat([self.future_games, new_df], ignore_index=True)
+        # Match real Season bookkeeping so .tail() / .loc[] work.
+        self.completed_games.index = range(len(self.completed_games))
+        start = (
+            (max(self.completed_games.index) + 1)
+            if len(self.completed_games) > 0
+            else 0
+        )
+        self.future_games.index = range(start, start + len(self.future_games))
+
     def append_future_game(
         self, future_games, date, team, opponent, playoff_label=None
     ):
-        new_row = pd.DataFrame(
-            {
-                "date": [date],
-                "team": [team],
-                "opponent": [opponent],
-                "year": [self.year],
-                "playoff_label": [playoff_label],
-                "playoff": [1],
-                "winner_name": [np.nan],
-            }
-        )
-        self.future_games = pd.concat([self.future_games, new_row], ignore_index=True)
-        # Match real Season bookkeeping so .tail() / .loc[] work.
-        self.completed_games.index = range(len(self.completed_games))
-        self.future_games.index = range(
-            (
-                (max(self.completed_games.index) + 1)
-                if len(self.completed_games) > 0
-                else 0
-            ),
-            (
-                max(self.completed_games.index) + 1
-                if len(self.completed_games) > 0
-                else 0
-            )
-            + len(self.future_games),
+        self.append_future_games(
+            [
+                {
+                    "date": date,
+                    "team": team,
+                    "opponent": opponent,
+                    "playoff_label": playoff_label,
+                }
+            ]
         )
 
     def update_data(self, games_on_date=None):


### PR DESCRIPTION
## Summary

Five small refactors that pivot off pandas DataFrames where a plain dict, list of dicts, or vectorized op expresses the intent more clearly. Several of these eliminate the ordering-dependent `.iloc[-1]` patterns that produced PR #43's silent-data-corruption bugs.

All changes preserve behavior; full test suite (112 tests, excluding the network-only `test_nba_api_loader::test_rate_limiting`) passes locally.

### `src/forecast.py` — drop the dict→DataFrame→re-filter round-trip
`get_predictive_ratings_win_margin` previously stored each team's most-recent game in a dict, wrapped it back into a DataFrame, sorted it, and then re-filtered+took `iloc[-1]` per team to pick out features — across two nested loops, with a `team_df["team"].iloc[-1] == team` branch repeated 7× per team. That's exactly the pattern that produced our recent bugs.

Now: build `team_snapshots: dict[team, dict[feature, value]]` once via a new `_team_features_from_game(team, row)` helper that normalizes feature names to the team's perspective up front. The nested loop becomes plain dict lookups — no `.iloc[-1]`, no side-detection branch, no DataFrame round-trip.

### `src/stats.py`
- **`get_remaining_sos`**: replace the per-row `ratings_df[ratings_df["team"]==x]["predictive_rating"].values[0]` filter (O(games × teams) DataFrame filters) with a single `dict(zip(...))` lookup table.
- **`get_offensive_efficiency` / `get_defensive_efficiency`**: vectorize via `groupby("team")["eff"].mean()` instead of `iterrows()` + per-team list accumulation. Shared logic pulled into `_team_efficiency`.

### `src/sim_season.py`
- Replace two `iterrows()`-to-dict loops with `dict(zip(...))` for `end_season_standings`.
- Add `append_future_games(rows)` that does **one** `pd.concat` + one index reset for a batch of new games. The two playoff hot loops (per-series scheduling and play-in scheduling) now build a list of dicts and call the batched method, avoiding O(n²) growth from per-row `pd.concat` (a series of 7 games used to do 7 concats + 7 index resets; now 1 of each). Existing single-row `append_future_game` is kept as a thin wrapper for backward compat.

### `tests/test_play_in_detection.py`
Update `FakePlayInSeason` stub to mirror the new `append_future_game(s)` singular/plural split so it exercises the same code path as the real Season.

## Test plan
- [x] `pytest tests/ --ignore=tests/test_nba_api_loader.py` — 112 passed (the ignored file is a network-only integration test that fails locally due to sandbox restrictions, unrelated to these changes)
- [x] `black --check .` clean
- [x] `isort --check-only .` clean
- [x] Numerical sanity check on `get_offensive_efficiency` / `get_defensive_efficiency` / `get_remaining_sos` against worked examples


---
_Generated by [Claude Code](https://claude.ai/code/session_01TRA7gacjWovNfKRUKUBUHE)_